### PR TITLE
Proposed: Extension classes with Broadcast Channels

### DIFF
--- a/clients/Messages.ts
+++ b/clients/Messages.ts
@@ -1,0 +1,32 @@
+import { type SignedState } from './StateChannelWallet'
+
+export enum MessageType {
+  RequestInvoice = 'requestInvoice',
+  Invoice = 'invoice',
+  ForwardPayment = 'forwardPayment'
+}
+
+export type Message = Invoice | RequestInvoice | ForwardPaymentRequest
+export interface Invoice {
+  type: MessageType.Invoice
+  amount: number
+  hashLock: string
+}
+interface RequestInvoice {
+  type: MessageType.RequestInvoice
+  amount: number
+}
+interface ForwardPaymentRequest {
+  type: MessageType.ForwardPayment
+  target: string // scw address whose owner is the payee
+  amount: number
+  hashLock: string
+  timelock: number
+  updatedState: SignedState // includes the "source" HTLC which makes the payment safe for the intermediary
+}
+
+/**
+ * A shim type on top of BroadcastChannel's MessageEvent, which passes
+ * message payload through the `data` property.
+ */
+export type scwMessageEvent = MessageEvent & { data: Message }

--- a/clients/OwnerClient.ts
+++ b/clients/OwnerClient.ts
@@ -1,0 +1,59 @@
+import { type Invoice, type scwMessageEvent, MessageType } from './Messages'
+import { Participant, StateChannelWallet, type StateChannelWalletParams } from './StateChannelWallet'
+
+export class OwnerClient extends StateChannelWallet {
+  static async create (params: StateChannelWalletParams): Promise<OwnerClient> {
+    const instance = new OwnerClient(params)
+
+    if (instance.myRole() !== Participant.Owner) {
+      throw new Error('Signer is not owner')
+    }
+
+    return instance
+  }
+
+  /**
+   * Coordinates with the payee to transfer funds to them. Payee is first
+   * asked for a hashlock, then the lock is used to forward payment via
+   * the intermediary.
+   *
+   * @param payee the SCBridgeWallet address we want to pay to
+   * @param amount the amount we want to pay
+   */
+  async pay (payee: string, amount: number): Promise<void> {
+    // contact `payee` and request a hashlock
+    const bc = new BroadcastChannel(payee + '-global')
+    bc.postMessage({ type: 'requestInvoice' })
+
+    const invoice: Invoice = await new Promise((resolve, reject) => {
+      bc.onmessage = (ev: scwMessageEvent) => {
+        if (ev.data.type === MessageType.Invoice) {
+          resolve(ev.data)
+        } else {
+          reject(new Error('Unexpected message type'))
+        }
+      }
+    })
+
+    // create a state update with the hashlock
+    const signedUpdate = await this.addHTLC(amount, invoice.hashLock)
+
+    // send the state update to the intermediary
+    this.sendPeerMessage({
+      type: MessageType.ForwardPayment,
+      target: payee,
+      amount,
+      hashLock: invoice.hashLock,
+      timelock: 0, // todo
+      updatedState: signedUpdate
+    })
+  }
+
+  // todo: add listener for invoice requests (always accept - they want to pay us)
+
+  // todo: add function to direct L1 payments / general transactions to UserOperations
+  //       and forward to intermediary
+
+  // todo: add listener for incoming HTLCs which correspond to some preimage we know.
+  //       When they arrive, we claim the funds and maybe clear the invoice in some way.
+}

--- a/clients/StateChannelWallet.ts
+++ b/clients/StateChannelWallet.ts
@@ -50,6 +50,11 @@ export class StateChannelWallet {
     return Number(this.intermediaryBalance)
   }
 
+  async getOwnerBalance (): Promise<number> {
+    const walletBalance = await this.getBalance();
+    return walletBalance - await this.getIntermediaryBalance();
+  }
+
   async getCurrentBlockNumber (): Promise<number> {
     const blockNumber = await this.chainProvider.getBlockNumber()
     return blockNumber

--- a/clients/StateChannelWallet.ts
+++ b/clients/StateChannelWallet.ts
@@ -103,8 +103,12 @@ export class StateChannelWallet {
   // Craft an HTLC struct, put it inside a state, hash the state, sign and return it
   async createHTLCPayment (toAddress: string, amount: number, hash: string): Promise<string> {
     const currentTimestamp: number = Math.floor(Date.now() / 1000) // Unix timestamp in seconds
+    if (toAddress === this.signer.address) {
+      throw new Error('Cannot create HTLC to self')
+    }
+
     const htlc: HTLCStruct = {
-      to: toAddress,
+      to: this.theirRole(),
       amount,
       hashLock: hash,
       timelock: currentTimestamp + HTLC_TIMEOUT * 2 // payment creator always uses TIMEOUT * 2

--- a/clients/StateChannelWallet.ts
+++ b/clients/StateChannelWallet.ts
@@ -52,8 +52,8 @@ export class StateChannelWallet {
   }
 
   async getOwnerBalance (): Promise<number> {
-    const walletBalance = await this.getBalance();
-    return walletBalance - await this.getIntermediaryBalance();
+    const walletBalance = await this.getBalance()
+    return walletBalance - await this.getIntermediaryBalance()
   }
 
   async getCurrentBlockNumber (): Promise<number> {

--- a/clients/StateChannelWallet.ts
+++ b/clients/StateChannelWallet.ts
@@ -109,6 +109,17 @@ export class StateChannelWallet {
     return hash
   }
 
+  // returns the state with largest turnNum that is signed by both parties
+  currentState (): StateStruct {
+    for (let i = this.signedStates.length - 1; i >= 0; i--) {
+      const signedState = this.signedStates[i]
+      if (signedState.intermediarySignature !== '' && signedState.ownerSignature !== '') {
+        return signedState.state
+      }
+    }
+    throw new Error('No signed state found')
+  }
+
   // Craft an HTLC struct, put it inside a state, hash the state, sign and return it
   async addHTLC (amount: number, hash: string): Promise<SignedState> {
     const currentTimestamp: number = Math.floor(Date.now() / 1000) // Unix timestamp in seconds

--- a/clients/StateChannelWallet.ts
+++ b/clients/StateChannelWallet.ts
@@ -2,15 +2,16 @@ import { ethers } from 'ethers'
 import { type UserOperationStruct, type HTLCStruct, type StateStruct, type NitroSmartContractWallet } from '../typechain-types/contracts/Nitro-SCW.sol/NitroSmartContractWallet'
 import { signUserOp } from './UserOp'
 import { NitroSmartContractWallet__factory } from '../typechain-types'
+import { type Message } from './Messages'
 
 const HTLC_TIMEOUT = 5 * 60 // 5 minutes
 
-enum Participant {
+export enum Participant {
   Owner = 0,
   Intermediary = 1
 }
 
-interface StateChannelWalletParams {
+export interface StateChannelWalletParams {
   signingKey: string
   chainRpcUrl: string
   entrypointAddress: string
@@ -24,6 +25,15 @@ export interface SignedState {
 }
 
 export class StateChannelWallet {
+  protected readonly chainProvider: ethers.Provider
+  protected readonly signer: ethers.Wallet
+  protected readonly entrypointAddress: string
+  protected ownerAddress: string
+  protected intermediaryAddress: string
+  protected intermediaryBalance: bigint
+  protected readonly scwAddress: string
+  protected readonly contract: NitroSmartContractWallet
+  protected readonly hashStore: Map<string, Uint8Array> // maps hash-->preimage
   protected readonly peerBroadcastChannel: BroadcastChannel
   protected readonly globalBroadcastChannel: BroadcastChannel
   /**

--- a/clients/StateChannelWallet.ts
+++ b/clients/StateChannelWallet.ts
@@ -1,5 +1,5 @@
 import { ethers } from 'ethers'
-import { type UserOperationStruct, type HTLCStruct, type StateStruct, type NitroSmartContractWallet } from '../typechain-types/Nitro-SCW.sol/NitroSmartContractWallet'
+import { type UserOperationStruct, type HTLCStruct, type StateStruct, type NitroSmartContractWallet } from '../typechain-types/contracts/Nitro-SCW.sol/NitroSmartContractWallet'
 import { signUserOp } from './UserOp'
 import { NitroSmartContractWallet__factory } from '../typechain-types'
 

--- a/clients/StateChannelWallet.ts
+++ b/clients/StateChannelWallet.ts
@@ -24,6 +24,8 @@ export interface SignedState {
 }
 
 export class StateChannelWallet {
+  protected readonly peerBroadcastChannel: BroadcastChannel
+  protected readonly globalBroadcastChannel: BroadcastChannel
   /**
    * Signed states are stored as long as they are deemed useful. All stored
    * signatures are valid.
@@ -35,6 +37,8 @@ export class StateChannelWallet {
     this.entrypointAddress = params.entrypointAddress
     this.scwAddress = params.scwAddress
     this.chainProvider = new ethers.JsonRpcProvider(params.chainRpcUrl)
+    this.peerBroadcastChannel = new BroadcastChannel(this.scwAddress + '-peer')
+    this.globalBroadcastChannel = new BroadcastChannel(this.scwAddress + '-global')
 
     const wallet = new ethers.Wallet(params.signingKey)
     this.signer = wallet.connect(this.chainProvider)
@@ -55,6 +59,10 @@ export class StateChannelWallet {
     instance.ownerAddress = await instance.contract.owner()
 
     return instance
+  }
+
+  sendPeerMessage (message: Message): void {
+    this.peerBroadcastChannel.postMessage(message)
   }
 
   myRole (): Participant {

--- a/clients/StateChannelWallet.ts
+++ b/clients/StateChannelWallet.ts
@@ -10,6 +10,13 @@ enum Participant {
   Intermediary = 1
 }
 
+interface StateChannelWalletParams {
+  signingKey: string
+  chainRpcUrl: string
+  entrypointAddress: string
+  scwAddress: string
+}
+
 export class StateChannelWallet {
   private readonly chainProvider: ethers.Provider
   private readonly signer: ethers.Wallet
@@ -21,7 +28,7 @@ export class StateChannelWallet {
   private readonly contract: NitroSmartContractWallet
   private readonly hashStore: Map<string, Uint8Array> // maps hash-->preimage
 
-  constructor (params: { signingKey: string, chainRpcUrl: string, entrypointAddress: string, scwAddress: string }) {
+  constructor (params: StateChannelWalletParams) {
     this.hashStore = new Map<string, Uint8Array>()
     this.entrypointAddress = params.entrypointAddress
     this.scwAddress = params.scwAddress
@@ -38,7 +45,7 @@ export class StateChannelWallet {
     this.intermediaryBalance = BigInt(0)
   }
 
-  static async create (params: { signingKey: string, chainRpcUrl: string, entrypointAddress: string, scwAddress: string }): Promise<StateChannelWallet> {
+  static async create (params: StateChannelWalletParams): Promise<StateChannelWallet> {
     const instance = new StateChannelWallet(params)
 
     instance.intermediaryAddress = await instance.contract.intermediary()

--- a/clients/StateChannelWallet.ts
+++ b/clients/StateChannelWallet.ts
@@ -41,6 +41,7 @@ export class StateChannelWallet {
   }
 
   async getBalance (): Promise<number> {
+    // todo: caching, block event based updating, etc
     const balance = await this.chainProvider.getBalance(this.scwAddress)
     const balanceEther = ethers.formatEther(balance)
     return Number(balanceEther)

--- a/contracts/Nitro-SCW.sol
+++ b/contracts/Nitro-SCW.sol
@@ -5,7 +5,7 @@ pragma solidity 0.8.19;
 import {IAccount} from "contracts/interfaces/IAccount.sol";
 import {UserOperation} from "contracts/interfaces/UserOperation.sol";
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
-import {HTLC, State, hashState, checkSignatures, Payee} from "./state.sol";
+import {HTLC, State, hashState, checkSignatures, Participant} from "./state.sol";
 enum WalletStatus {
     OPEN,
     CHALLENGE_RAISED,
@@ -47,7 +47,7 @@ contract NitroSmartContractWallet is IAccount {
 
         removeActiveHTLC(hashLock);
 
-        if (htlc.to == Payee.INTERMEDIARY) {
+        if (htlc.to == Participant.INTERMEDIARY) {
             intermediaryBalance += htlc.amount;
         }
     }
@@ -73,7 +73,7 @@ contract NitroSmartContractWallet is IAccount {
         // Release any expired funds back to the sender
         for (uint i = 0; i < activeHTLCs.length; i++) {
             HTLC memory htlc = htlcs[activeHTLCs[i]];
-            if (htlc.to == Payee.OWNER) {
+            if (htlc.to == Participant.OWNER) {
                 intermediary.transfer(htlc.amount);
             } else {
                 owner.transfer(htlc.amount);

--- a/contracts/state.sol
+++ b/contracts/state.sol
@@ -10,13 +10,13 @@ struct State {
     HTLC[] htlcs;
 }
 
-enum Payee {
+enum Participant {
     OWNER,
     INTERMEDIARY
 }
 
 struct HTLC {
-    Payee to;
+    Participant to;
     uint amount;
     bytes32 hashLock;
     uint timelock;

--- a/test/Nitro-SCW.ts
+++ b/test/Nitro-SCW.ts
@@ -9,7 +9,7 @@ import { time } from '@nomicfoundation/hardhat-network-helpers'
 import { type UserOperationStruct, type StateStruct } from '../typechain-types/contracts/Nitro-SCW.sol/NitroSmartContractWallet'
 const ONE_DAY = 86400
 const TIMELOCK_DELAY = 1000
-const enum Payee { Owner = 0, Intermediary = 1 }
+const enum Participant { Owner = 0, Intermediary = 1 }
 async function getBlockTimestamp (): Promise<number> {
   const blockNum = await hre.ethers.provider.getBlockNumber()
   const block = await hre.ethers.provider.getBlock(blockNum)
@@ -54,7 +54,7 @@ describe('Nitro-SCW', function () {
         htlcs: [
           {
             amount: 0,
-            to: Payee.Intermediary,
+            to: Participant.Intermediary,
             hashLock: ethers.ZeroHash,
             timelock: (await getBlockTimestamp()) + 1000
           }
@@ -78,7 +78,7 @@ describe('Nitro-SCW', function () {
         htlcs: [
           {
             amount: 0,
-            to: Payee.Intermediary,
+            to: Participant.Intermediary,
             hashLock: ethers.ZeroHash,
             timelock: (await getBlockTimestamp()) + 1000
           }
@@ -106,7 +106,7 @@ describe('Nitro-SCW', function () {
         htlcs: [
           {
             amount: 0,
-            to: Payee.Intermediary,
+            to: Participant.Intermediary,
             hashLock: hash,
             timelock: (await getBlockTimestamp()) + TIMELOCK_DELAY
           }
@@ -142,7 +142,7 @@ describe('Nitro-SCW', function () {
         htlcs: [
           {
             amount: 0,
-            to: Payee.Intermediary,
+            to: Participant.Intermediary,
             hashLock: hash,
             timelock: (await getBlockTimestamp()) + 1000
           }


### PR DESCRIPTION
Stacked on #35 


This PR takes some opinionated steps forward:

1. it defines a few of the peer message types required in the system (still remaining things like `cosign` helpers and maybe others) (#7)
2. it suggests a split of the base class into separate APIs for wallet owners and wallet intermediaries - the `pay` method of the `OwnerClient` is implemented (#6)
3. it sets up two `BroadcastChannel`s for each channel - one for communication between the channel participants, and one for the receipt of messages from outside of the channel. (#18)

Follow-on work to get to an end-to-end payment running is
- to make `IntermediaryClient` which can receive, inspect, and decide whether to honor a `ForwardPayment` message (should reject if the sender does not actually have funds to cover the added HTLC)
- to make the `OwnerClient` responsive to `RequestInvoice` messages

PR is lacking in test coverage - hence draft.