### PR TITLE
Return invoices on request

### DIFF
--- a/clients/OwnerClient.ts
+++ b/clients/OwnerClient.ts
@@ -27,12 +27,11 @@ export class OwnerClient extends StateChannelWallet {
    */
   async pay(payee: string, amount: number): Promise<void> {
     // contact `payee` and request a hashlock
-    const bc = new BroadcastChannel(payee + "-global");
-    bc.postMessage({ type: "requestInvoice" });
+    const requestChannel = this.sendGlobalMessage(payee, {type: MessageType.RequestInvoice, amount, from: this.scwAddress})
 
     const invoice: Invoice = await new Promise((resolve, reject) => {
       // todo: resolve failure on a timeout
-      bc.onmessage = (ev: scwMessageEvent) => {
+      requestChannel.onmessage = (ev: scwMessageEvent) => {
         if (ev.data.type === MessageType.Invoice) {
           resolve(ev.data);
         } else {

--- a/clients/OwnerClient.ts
+++ b/clients/OwnerClient.ts
@@ -52,7 +52,7 @@ export class OwnerClient extends StateChannelWallet {
    */
   async pay(payee: string, amount: number): Promise<void> {
     // contact `payee` and request a hashlock
-    const requestChannel = this.sendGlobalMessage(payee, {type: MessageType.RequestInvoice, amount, from: this.scwAddress})
+    const requestChannel = this.sendGlobalMessage(payee, {type: MessageType.RequestInvoice, amount})
 
     const invoice: Invoice = await new Promise((resolve, reject) => {
       // todo: resolve failure on a timeout

--- a/clients/OwnerClient.ts
+++ b/clients/OwnerClient.ts
@@ -31,6 +31,7 @@ export class OwnerClient extends StateChannelWallet {
     bc.postMessage({ type: "requestInvoice" });
 
     const invoice: Invoice = await new Promise((resolve, reject) => {
+      // todo: resolve failure on a timeout
       bc.onmessage = (ev: scwMessageEvent) => {
         if (ev.data.type === MessageType.Invoice) {
           resolve(ev.data);

--- a/clients/OwnerClient.ts
+++ b/clients/OwnerClient.ts
@@ -12,7 +12,7 @@ export class OwnerClient extends StateChannelWallet {
     this.attachMessageHandlers();
   }
 
-  private attachMessageHandlers() {
+  private attachMessageHandlers(): void {
     // These handlers are for messages from parties outside of our wallet / channel.
     this.globalBroadcastChannel.onmessage = async (ev: scwMessageEvent) => {
       const req = ev.data;
@@ -52,7 +52,10 @@ export class OwnerClient extends StateChannelWallet {
    */
   async pay(payee: string, amount: number): Promise<void> {
     // contact `payee` and request a hashlock
-    const requestChannel = this.sendGlobalMessage(payee, {type: MessageType.RequestInvoice, amount})
+    const requestChannel = this.sendGlobalMessage(payee, {
+      type: MessageType.RequestInvoice,
+      amount,
+    });
 
     const invoice: Invoice = await new Promise((resolve, reject) => {
       // todo: resolve failure on a timeout

--- a/clients/StateChannelWallet.ts
+++ b/clients/StateChannelWallet.ts
@@ -96,10 +96,10 @@ export class StateChannelWallet {
 
   /**
    * Sends a message to a network participant who is *not* our channel peer.
-   * 
+   *
    * Convention: send outgoing requests to a peer via this method, and listen for
    * request-scoped responses on the returned channel.
-   * 
+   *
    * @param to the scwAddress of the recipient
    * @param message the protocol message to send
    * @returns the broadcast channel used to send the message, in order to listen for replies

--- a/clients/StateChannelWallet.ts
+++ b/clients/StateChannelWallet.ts
@@ -94,6 +94,22 @@ export class StateChannelWallet {
     this.peerBroadcastChannel.postMessage(message);
   }
 
+  /**
+   * Sends a message to a network participant who is *not* our channel peer.
+   * 
+   * Convention: send outgoing requests to a peer via this method, and listen for
+   * request-scoped responses on the returned channel.
+   * 
+   * @param to the scwAddress of the recipient
+   * @param message the protocol message to send
+   * @returns the broadcast channel used to send the message, in order to listen for replies
+   */
+  sendGlobalMessage(to: string, message: Message): BroadcastChannel {
+    const toChannel = new BroadcastChannel(to + "-global");
+    toChannel.postMessage(message);
+    return toChannel;
+  }
+
   myRole(): Participant {
     if (this.signer.address === this.ownerAddress) {
       return Participant.Owner;


### PR DESCRIPTION
PR adds some helpers for global messaging and a convention: where global messages expect an immediate response, the response is returned directly on the same `BroadcastChannel` that receives the request. This allows the lifecycle of each event to play out on a single channel.

The alternative is that the request receiver sends on the request sender's global broadcastChannel, but this feels clunkier.

No tests yet, but can potentially start to be wired against the UI for sanity checking.

Closes #40