### PR TITLE
Allow for non-EOA owners

### DIFF
--- a/contracts/Factory.sol
+++ b/contracts/Factory.sol
@@ -5,7 +5,7 @@ import "./Nitro-SCW.sol";
 
 contract SCBridgeAccountFactory {
     function createAccount(
-        address payable owner,
+        address owner,
         address payable intermediary,
         bytes32 salt
     ) public returns (address) {

--- a/contracts/Factory.sol
+++ b/contracts/Factory.sol
@@ -7,11 +7,16 @@ contract SCBridgeAccountFactory {
     function createAccount(
         address owner,
         address payable intermediary,
+        address entrypoint,
         bytes32 salt
     ) public returns (address) {
         return
             address(
-                new NitroSmartContractWallet{salt: salt}(owner, intermediary)
+                new NitroSmartContractWallet{salt: salt}(
+                    owner,
+                    intermediary,
+                    entrypoint
+                )
             );
     }
 }

--- a/contracts/Nitro-SCW.sol
+++ b/contracts/Nitro-SCW.sol
@@ -128,8 +128,8 @@ contract NitroSmartContractWallet is IAccount {
         uint256 value,
         bytes calldata func
     ) external {
-        if (getStatus() == WalletStatus.FINALIZED) {
-            // If the wallet has finalized then the owner can do whatever they want with the remaining funds
+        if (getStatus() == WalletStatus.FINALIZED && activeHTLCs.length == 0) {
+            // If the wallet has finalized and all the funds have been reclaimed then the owner can do whatever they want with the remaining funds
             // The owner can call this function directly or the entrypoint can call it on their behalf
             require(
                 msg.sender == entrypoint || msg.sender == owner,

--- a/contracts/Nitro-SCW.sol
+++ b/contracts/Nitro-SCW.sol
@@ -39,6 +39,9 @@ contract NitroSmartContractWallet is IAccount {
         return WalletStatus.CHALLENGE_RAISED;
     }
 
+    // Define the fallback function so that the wallet can receive funds
+    receive() external payable {}
+
     function unlockHTLC(bytes32 hashLock, bytes memory preImage) public {
         HTLC memory htlc = htlcs[hashLock];
 

--- a/test/Nitro-SCW.ts
+++ b/test/Nitro-SCW.ts
@@ -32,9 +32,6 @@ describe("UserOP submission", function () {
   });
 });
 describe("Nitro-SCW", function () {
-  // We define a fixture to reuse the same setup in every test.
-  // We use loadFixture to run this setup once, snapshot that state,
-  // and reset Hardhat Network to that snapshot in every test.
   async function deployNitroSCW(): Promise<{
     nitroSCW: NitroSmartContractWallet;
     owner: BaseWallet;
@@ -58,6 +55,12 @@ describe("Nitro-SCW", function () {
     });
 
     const nitroSCW = await deployer.deploy(owner, intermediary);
+
+    await hardhatFundedAccount.sendTransaction({
+      to: await nitroSCW.getAddress(),
+      value: ethers.parseEther("1.0"),
+    });
+
     return {
       nitroSCW: nitroSCW as unknown as NitroSmartContractWallet,
       owner,

--- a/test/Nitro-SCW.ts
+++ b/test/Nitro-SCW.ts
@@ -25,17 +25,12 @@ async function getBlockTimestamp(): Promise<number> {
   return block.timestamp;
 }
 
-describe("UserOP submission", function () {
-  it("should deploy the entrypoint", async function () {
-    const entryPointDeployer = await ethers.getContractFactory("EntryPoint");
-    await entryPointDeployer.deploy();
-  });
-});
 describe("Nitro-SCW", function () {
   async function deployNitroSCW(): Promise<{
     nitroSCW: NitroSmartContractWallet;
     owner: BaseWallet;
     intermediary: BaseWallet;
+    entrypoint: string;
   }> {
     const deployer = await hre.ethers.getContractFactory(
       "NitroSmartContractWallet",
@@ -54,7 +49,10 @@ describe("Nitro-SCW", function () {
       value: ethers.parseEther("1.0"),
     });
 
-    const nitroSCW = await deployer.deploy(owner, intermediary);
+    const entryPointDeployer = await ethers.getContractFactory("EntryPoint");
+    const entrypoint = await (await entryPointDeployer.deploy()).getAddress();
+
+    const nitroSCW = await deployer.deploy(owner, intermediary, entrypoint);
 
     await hardhatFundedAccount.sendTransaction({
       to: await nitroSCW.getAddress(),
@@ -65,6 +63,7 @@ describe("Nitro-SCW", function () {
       nitroSCW: nitroSCW as unknown as NitroSmartContractWallet,
       owner,
       intermediary,
+      entrypoint,
     };
   }
 


### PR DESCRIPTION
This PR makes a few small changes so that the `NitroSmartContractWallet` no longer requires the `owner` to own an EOA account.
- The `reclaim` function no longer transfers funds outside of the nitro SCW. Instead the funds are left in the wallet. 
- An `execute` function has been added (based on [this one](https://github.com/eth-infinitism/account-abstraction/blob/73a676999999843f5086ee546e192cbef25c0c4a/contracts/samples/SimpleAccount.sol#L57)). This would let the owner of the wallet execute any transaction they want to use the nitro SCW as a wallet.
- The SCW wallet has been updated to include the entrypoint address and uses it to guard the `Execute` function (based on [this sample](https://github.com/eth-infinitism/account-abstraction/blob/5b7b9715fa0c3743108982cf8826e6262fef6d68/contracts/samples/SimpleAccount.sol#L58)). When the Wallet is not finalized then only the `entrypoint` can call `execute`, enforcing that the only way funds are spent is by signed User Operations. When the wallet is finalized, the `owner` (if they have an EOA account) is allowed to spend the funds, since the intermediary has claimed them already.