### PR TITLE
allow LN compatible secret hashing

### DIFF
--- a/contracts/Nitro-SCW.sol
+++ b/contracts/Nitro-SCW.sol
@@ -43,7 +43,11 @@ contract NitroSmartContractWallet is IAccount {
         HTLC memory htlc = htlcs[hashLock];
 
         require(htlc.timelock > block.timestamp, "HTLC already expired");
-        require(htlc.hashLock == keccak256(preImage), "Invalid preImage");
+        require(
+            htlc.hashLock == keccak256(preImage) ||
+                htlc.hashLock == sha256(preImage),
+            "Invalid preImage"
+        );
 
         removeActiveHTLC(hashLock);
 

--- a/contracts/Nitro-SCW.sol
+++ b/contracts/Nitro-SCW.sol
@@ -45,7 +45,7 @@ contract NitroSmartContractWallet is IAccount {
         require(htlc.timelock > block.timestamp, "HTLC already expired");
         require(
             htlc.hashLock == keccak256(preImage) ||
-                htlc.hashLock == sha256(preImage),
+                htlc.hashLock == sha256(preImage), // For lightening network compatible HTLCs
             "Invalid preImage"
         );
 


### PR DESCRIPTION
very small PR checks preimage with LN's `sha256` as well as EVM friendly `keccak256`.