### PR TITLE
Fix UI by removing stale depency

### DIFF
--- a/clients/State.ts
+++ b/clients/State.ts
@@ -6,17 +6,17 @@ import {
   getBytes,
 } from "ethers";
 
-import { type StateStruct } from "../typechain-types/Nitro-SCW.sol/NitroSmartContractWallet";
+import { type StateStruct } from "../typechain-types/contracts/Nitro-SCW.sol/NitroSmartContractWallet";
 
-export function signStateHash(
+export async function signStateHash(
   stateHash: string,
   owner: BaseWallet,
   intermediary: BaseWallet,
-): [string, string] {
-  return [
-    owner.signMessageSync(getBytes(stateHash)),
-    intermediary.signMessageSync(getBytes(stateHash)),
-  ];
+): Promise<[string, string]> {
+  const ownerSig = await owner.signMessage(getBytes(stateHash));
+  const intermediarySig = await intermediary.signMessage(getBytes(stateHash));
+
+  return [ownerSig, intermediarySig];
 }
 
 export function encodeState(state: StateStruct): string {

--- a/clients/UserOp.ts
+++ b/clients/UserOp.ts
@@ -1,8 +1,8 @@
 // FYI: Based on https://github.com/eth-infinitism/account-abstraction/blob/5b7b9715fa0c3743108982cf8826e6262fef6d68/test/UserOp.ts#L56-L105
-import { AbiCoder, keccak256, getBytes, ZeroAddress } from "ethers";
+import { AbiCoder, getBytes, keccak256, ZeroAddress } from "ethers";
 import { type BaseWallet } from "ethers";
 
-import { type UserOperationStruct } from "../typechain-types/Nitro-SCW.sol/NitroSmartContractWallet";
+import { type UserOperationStruct } from "../typechain-types/contracts/Nitro-SCW.sol/NitroSmartContractWallet";
 
 export function packUserOp(
   op: UserOperationStruct,
@@ -124,15 +124,14 @@ export const DefaultsForUserOp: UserOperationStruct = {
   signature: "0x",
 };
 
-export function signUserOp(
+export async function signUserOp(
   op: UserOperationStruct,
   signer: BaseWallet,
   entryPoint: string,
   chainId: number,
-): string {
+): Promise<string> {
   const message = getUserOpHash(op, entryPoint, chainId);
-
-  return signer.signMessageSync(getBytes(message));
+  return await signer.signMessage(getBytes(message));
 }
 
 export function fillUserOpDefaults(

--- a/test/Nitro-SCW.test.ts
+++ b/test/Nitro-SCW.test.ts
@@ -97,7 +97,7 @@ describe("Nitro-SCW", function () {
 
       const stateHash = hashState(state);
 
-      const [ownerSig, intermediarySig] = signStateHash(
+      const [ownerSig, intermediarySig] = await signStateHash(
         stateHash,
         owner,
         intermediary,
@@ -139,7 +139,7 @@ describe("Nitro-SCW", function () {
 
       const stateHash = hashState(state);
 
-      const [ownerSig, intermediarySig] = signStateHash(
+      const [ownerSig, intermediarySig] = await signStateHash(
         stateHash,
         owner,
         intermediary,
@@ -177,13 +177,13 @@ describe("Nitro-SCW", function () {
         signature: hre.ethers.ZeroHash,
       };
 
-      const ownerSig = signUserOp(
+      const ownerSig = await signUserOp(
         userOp,
         owner,
         ethers.ZeroAddress,
         Number(n.chainId),
       );
-      const intermediarySig = signUserOp(
+      const intermediarySig = await signUserOp(
         userOp,
         intermediary,
         ethers.ZeroAddress,
@@ -220,7 +220,7 @@ describe("Nitro-SCW", function () {
         signature: hre.ethers.ZeroHash,
       };
 
-      const ownerSig = signUserOp(
+      const ownerSig = await signUserOp(
         userOp,
         owner,
         ethers.ZeroAddress,


### PR DESCRIPTION
It looks in two places in our code we were referencing `ethereumjs-util`, even though we didn't add it an explicit as a dependency. The `ethereumjs-util` repo had been archived and it seems like it uses some old `Buffer` functionality that has been deprecated in the browser.

This PR removes the code we were importing from `ethereumjs-util` so it doesn't get included. The UI now starts up as expected.