### PR TITLE
Refactor clients to remove messaging

### DIFF
--- a/clients/Messages.ts
+++ b/clients/Messages.ts
@@ -8,6 +8,10 @@ export enum MessageType {
   UserOperation = "userOperation",
 }
 
+export interface GlobalMessage {
+  to: string;
+  message: Message;
+}
 export type Message =
   | Invoice
   | RequestInvoice
@@ -17,6 +21,7 @@ export interface Invoice {
   type: MessageType.Invoice;
   amount: number;
   hashLock: string;
+  from: string;
 }
 interface RequestInvoice {
   type: MessageType.RequestInvoice;

--- a/src/Wallet.tsx
+++ b/src/Wallet.tsx
@@ -102,9 +102,12 @@ const Wallet: React.FunctionComponent<{ role: Role }> = (props: {
           <Button
             onClick={() => {
               console.log(
-                "sending: " + JSON.stringify(message) + " to: " + myPeer,
+                "pretending to be sending: " +
+                  JSON.stringify(message) +
+                  " to: " +
+                  myPeer,
               );
-              wallet.sendGlobalMessage(myPeer, message);
+              //   wallet.sendGlobalMessage(myPeer, message);
             }}
           >
             L2 Pay


### PR DESCRIPTION
Fixes #71 

This removes the use of the `BroadcastChannel` from the client. The goal of this is to allow us to create a simple test using the clients and manually exchanging messaging, without being coupled to the a browser environment to use the `BroadcastChannel`.

The approach I took is that all API functions return a message (`GlobalMessage|Message|undefined`) and every client has a `ReceiveMessage` function that can be called to ingest the message.  This requires a bit more reworking of the existing logic but it means that it should be very easy to start working on a test. The downside is that the existing `BroadcastChannel` logic is removed and we'll need to wire up listeners to Broadcast Channels outside of the client.


A slightly less destructive approach would be implementing a messaging service that the `client` can call send and receive on. In test we could use a simple in-memory implementation and use a BroadcastChannel implementation for the browser. That would require less changes to the existing logic but introduce a bit more work to testing, since we'd have to implement a test specific message service.