### PR TITLE
Unlock HTLCs when they are for us

### DIFF
--- a/clients/IntermediaryClient.ts
+++ b/clients/IntermediaryClient.ts
@@ -150,7 +150,7 @@ export class IntermediaryClient extends StateChannelWallet {
 
     // Bob has claimed is payment, so we now claim our linked payment from Alice
     // via the channel coordinator
-    this.coordinator.unlockHTLC(req);
+    void this.coordinator.unlockHTLC(req);
   }
 
   /**

--- a/clients/IntermediaryClient.ts
+++ b/clients/IntermediaryClient.ts
@@ -42,7 +42,7 @@ export class IntermediaryCoordinator {
    *
    * @param htlc the HTLC to forward
    */
-  async forwardHTLC(htlc: ForwardPaymentRequest): Promise<void> {
+  forwardHTLC(htlc: ForwardPaymentRequest): void {
     // Locate the target client
     const targetClient = this.channelClients.find(
       (c) => c.getAddress() === htlc.target,
@@ -54,10 +54,7 @@ export class IntermediaryCoordinator {
     }
 
     const fee = 0; // for example
-    const updatedState = await targetClient.addHTLC(
-      htlc.amount - fee,
-      htlc.hashLock,
-    );
+    const updatedState = targetClient.addHTLC(htlc.amount - fee, htlc.hashLock);
 
     targetClient.sendPeerMessage({
       type: MessageType.ForwardPayment,
@@ -115,7 +112,7 @@ export class IntermediaryClient extends StateChannelWallet {
           if (req.amount > (await this.getOwnerBalance())) {
             throw new Error("Insufficient balance");
           }
-          void this.coordinator.forwardHTLC(req);
+          this.coordinator.forwardHTLC(req);
           break;
         case MessageType.UserOperation:
           void this.handleUserOp(req);

--- a/clients/Messages.ts
+++ b/clients/Messages.ts
@@ -5,6 +5,7 @@ export enum MessageType {
   RequestInvoice = "requestInvoice",
   Invoice = "invoice",
   ForwardPayment = "forwardPayment",
+  UnlockHTLC = "unlockHTLC",
   UserOperation = "userOperation",
 }
 
@@ -12,6 +13,7 @@ export type Message =
   | Invoice
   | RequestInvoice
   | ForwardPaymentRequest
+  | UnlockHTLCRequest
   | UserOperation;
 export interface Invoice {
   type: MessageType.Invoice;
@@ -33,6 +35,19 @@ export interface ForwardPaymentRequest {
   hashLock: string;
   timelock: number;
   updatedState: SignedState; // includes the "source" HTLC which makes the payment safe for the intermediary
+}
+export interface UnlockHTLCRequest {
+  type: MessageType.UnlockHTLC;
+  /**
+   * the preimage that unlocks the HTLC. This is the evidence that our peer
+   * needs to recognize the legitimacy of the proposed state update.
+   */
+  preimage: string;
+  /**
+   * the updated state after the HTLC is unlocked. This is the state that
+   * we are seeking agreement on.
+   */
+  updatedState: SignedState;
 }
 
 interface UserOperation extends UserOperationStruct {

--- a/clients/Messages.ts
+++ b/clients/Messages.ts
@@ -42,7 +42,7 @@ export interface UnlockHTLCRequest {
    * the preimage that unlocks the HTLC. This is the evidence that our peer
    * needs to recognize the legitimacy of the proposed state update.
    */
-  preimage: string;
+  preimage: Uint8Array;
   /**
    * the updated state after the HTLC is unlocked. This is the state that
    * we are seeking agreement on.

--- a/clients/OwnerClient.ts
+++ b/clients/OwnerClient.ts
@@ -120,7 +120,7 @@ export class OwnerClient extends StateChannelWallet {
     });
 
     // create a state update with the hashlock
-    const signedUpdate = await this.addHTLC(amount, invoice.hashLock);
+    const signedUpdate = this.addHTLC(amount, invoice.hashLock);
 
     // send the state update to the intermediary
     this.sendPeerMessage({

--- a/clients/OwnerClient.ts
+++ b/clients/OwnerClient.ts
@@ -54,7 +54,7 @@ export class OwnerClient extends StateChannelWallet {
 
         this.sendPeerMessage({
           type: MessageType.UnlockHTLC,
-          preimage: preimage.toString(),
+          preimage,
           updatedState: updated,
         });
       }

--- a/clients/StateChannelWallet.ts
+++ b/clients/StateChannelWallet.ts
@@ -204,11 +204,12 @@ export class StateChannelWallet {
   async addHTLC(amount: number, hash: string): Promise<SignedState> {
     const currentTimestamp: number = Math.floor(Date.now() / 1000); // Unix timestamp in seconds
 
-    if (
-      this.myRole() === Participant.Intermediary &&
-      this.intermediaryBalance < BigInt(amount)
-    ) {
-      throw new Error("Insufficient balance");
+    if (this.myRole() === Participant.Intermediary) {
+      if (this.intermediaryBalance < BigInt(amount)) {
+        throw new Error("Insufficient balance");
+      }
+
+      this.intermediaryBalance -= BigInt(amount);
     }
 
     if (

--- a/clients/StateChannelWallet.ts
+++ b/clients/StateChannelWallet.ts
@@ -252,7 +252,7 @@ export class StateChannelWallet {
     return await this.signState(updated);
   }
 
-  async unlockHTLC(preimage: string): Promise<SignedState> {
+  async unlockHTLC(preimage: Uint8Array): Promise<SignedState> {
     // hash the preimage w/ keccak256 and sha256
     const ethHash = ethers.keccak256(preimage);
     const lnHash = ethers.sha256(preimage);

--- a/clients/StateChannelWallet.ts
+++ b/clients/StateChannelWallet.ts
@@ -201,9 +201,9 @@ export class StateChannelWallet {
     throw new Error("No signed state found");
   }
 
-  async signState(s: StateStruct): Promise<SignedState> {
+  signState(s: StateStruct): SignedState {
     const stateHash = hashState(s);
-    const signature: string = await this.signer.signMessage(stateHash);
+    const signature: string = this.signer.signMessageSync(stateHash);
 
     const signedState: SignedState = {
       state: s,
@@ -216,7 +216,7 @@ export class StateChannelWallet {
   }
 
   // Craft an HTLC struct, put it inside a state, hash the state, sign and return it
-  async addHTLC(amount: number, hash: string): Promise<SignedState> {
+  addHTLC(amount: number, hash: string): SignedState {
     const currentTimestamp: number = Math.floor(Date.now() / 1000); // Unix timestamp in seconds
 
     if (this.myRole() === Participant.Intermediary) {
@@ -249,7 +249,7 @@ export class StateChannelWallet {
       htlcs: [...this.currentState().htlcs, htlc],
     };
 
-    return await this.signState(updated);
+    return this.signState(updated);
   }
 
   async unlockHTLC(preimage: Uint8Array): Promise<SignedState> {
@@ -287,6 +287,6 @@ export class StateChannelWallet {
       htlcs: this.currentState().htlcs.filter((h) => h !== unlockTarget),
     };
 
-    return await this.signState(updated);
+    return this.signState(updated);
   }
 }

--- a/clients/StateChannelWallet.ts
+++ b/clients/StateChannelWallet.ts
@@ -194,6 +194,7 @@ export class StateChannelWallet {
         signedState.intermediarySignature !== "" &&
         signedState.ownerSignature !== ""
       ) {
+        // todo: deep copy?
         return signedState.state;
       }
     }


### PR DESCRIPTION
PR should complete the flow for a Alice-Irene-Bob HTLC payment.

- [x] add an unlockHTLC method on the base class (inspect preimage, find a match, remove it, adjust balances, create and sign new state)
- [x] add a listener that triggers Bob to unlock on receipt of his HTLC
- [x] have Irene unlock her HTLC from Alice after Bob runs the unlock protocol in Irene:Bob

closes #74 

PR suffers from some duplication due to the way that the handlers are attached to client message services. Could be fixed with a refactor, but maybe higher immediate priority is to prove out the payment lifecycle via UI integration?