### PR TITLE
Remove race condition

### DIFF
--- a/clients/OwnerClient.ts
+++ b/clients/OwnerClient.ts
@@ -34,8 +34,8 @@ export class OwnerClient extends StateChannelWallet {
           amount: req.amount,
         };
 
-        // return the invoice to the payer
-        this.sendGlobalMessage(req.from, invoice);
+        // return the invoice to the payer on the same channel we received the request
+        this.globalBroadcastChannel.postMessage(invoice);
       }
     };
 
@@ -100,28 +100,16 @@ export class OwnerClient extends StateChannelWallet {
    * @param amount the amount we want to pay
    */
   async pay(payee: string, amount: number): Promise<void> {
-    // start listening for an invoice
-    const invoicePromise = new Promise((resolve, reject) => {
-      // todo: resolve failure on a timeout
-      this.globalBroadcastChannel.onmessage = (ev: scwMessageEvent) => {
-        if (ev.data.type === MessageType.Invoice) {
-          resolve(ev.data);
-        } else {
-          // todo: fallback to L1 payment ?
-          reject(new Error("Unexpected message type"));
-        }
-      };
-    });
-
-    // contact `payee` and request a hashlock
-    this.sendGlobalMessage(payee, {
+    // contact `payee` and request an invoice
+    const invoice = await this.sendGlobalMessage(payee, {
       type: MessageType.RequestInvoice,
       amount,
       from: this.ownerAddress,
     });
 
-    // wait for invoice
-    const invoice: Invoice = (await invoicePromise) as Invoice;
+    if (invoice.type !== MessageType.Invoice) {
+      throw new Error("Unexpected response");
+    }
 
     // create a state update with the hashlock
     const signedUpdate = this.addHTLC(amount, invoice.hashLock);

--- a/clients/OwnerClient.ts
+++ b/clients/OwnerClient.ts
@@ -159,9 +159,4 @@ export class OwnerClient extends StateChannelWallet {
       ...signedUserOp,
     });
   }
-
-  // todo: add listener for invoice requests (always accept - they want to pay us)
-
-  // todo: add listener for incoming HTLCs which correspond to some preimage we know.
-  //       When they arrive, we claim the funds and maybe clear the invoice in some way.
 }

--- a/clients/StateChannelWallet.ts
+++ b/clients/StateChannelWallet.ts
@@ -117,7 +117,6 @@ export class StateChannelWallet {
    */
   async sendGlobalMessage(to: string, message: Message): Promise<Message> {
     const toChannel = new BroadcastChannel(to + "-global");
-    toChannel.postMessage(message);
 
     // todo: (out of scope) create a request-scoped broadcastChannel for the response,
     //       to avoid accidentally returning an unrelated message (e.g. from a previous interaction)
@@ -129,6 +128,8 @@ export class StateChannelWallet {
         resolve(ev.data);
       };
     });
+
+    toChannel.postMessage(message);
 
     return await respPromise;
   }


### PR DESCRIPTION
Previously, a listener was attached to a channel after a request was made. If the response returned before the listener was hooked up, it would be missed.

Now, the sendGlobalMessage() method establishes the listener internally before sending the request. It returns the awaited response.

closes #82 