### PR TITLE
Pay L1 flow

### DIFF
--- a/clients/IntermediaryClient.ts
+++ b/clients/IntermediaryClient.ts
@@ -175,7 +175,7 @@ export class IntermediaryClient extends StateChannelWallet {
       throw new Error("Transfer amount exceeds owner balance");
     }
 
-    const ownerSig = userOp.signature.slice(0, 65);
+    const ownerSig = userOp.signature.slice(0, 64);
     const { signature: intermediarySig } = await this.signUserOperation(userOp);
     userOp.signature = ethers.concat([ownerSig, intermediarySig]);
 

--- a/clients/IntermediaryClient.ts
+++ b/clients/IntermediaryClient.ts
@@ -175,7 +175,7 @@ export class IntermediaryClient extends StateChannelWallet {
       throw new Error("Transfer amount exceeds owner balance");
     }
 
-    const ownerSig = userOp.signature.slice(0, 64);
+    const ownerSig = userOp.signature;
     const { signature: intermediarySig } = await this.signUserOperation(userOp);
     userOp.signature = ethers.concat([ownerSig, intermediarySig]);
 

--- a/clients/StateChannelWallet.ts
+++ b/clients/StateChannelWallet.ts
@@ -74,7 +74,7 @@ export class StateChannelWallet {
 
     this.entrypointContract = EntryPoint__factory.connect(
       this.entrypointAddress,
-      this.chainProvider,
+      this.signer,
     );
 
     this.scwContract = SCBridgeWallet__factory.connect(

--- a/src/Intermediary.tsx
+++ b/src/Intermediary.tsx
@@ -21,24 +21,30 @@ export const Coordinator: React.FunctionComponent = () => {
   const myAddress = import.meta.env.VITE_IRENE_ADDRESS;
   // @ts-expect-error
   const myKey = import.meta.env.VITE_IRENE_SK;
+  // @ts-expect-error
+  const entrypointAddress = import.meta.env.VITE_ENTRYPOINT_ADDRESS;
+  // @ts-expect-error
+  const aliceScwAddress = import.meta.env.VITE_ALICE_SCW_ADDRESS;
+  // @ts-expect-error
+  const bobScwAddress = import.meta.env.VITE_BOB_SCW_ADDRESS;
 
   const withAlice = new IntermediaryClient({
     signingKey: myKey,
     // @ts-expect-error
     ownerAddress: import.meta.env.VITE_ALICE_ADDRESS,
     intermediaryAddress: myAddress,
-    chainRpcUrl: "",
-    entrypointAddress: "",
-    scwAddress: "",
+    chainRpcUrl: "http://localhost:8545",
+    entrypointAddress: entrypointAddress,
+    scwAddress: aliceScwAddress,
   });
   const withBob = new IntermediaryClient({
     signingKey: myKey,
     // @ts-expect-error
     ownerAddress: import.meta.env.VITE_BOB_ADDRESS,
     intermediaryAddress: myAddress,
-    chainRpcUrl: "",
-    entrypointAddress: "",
-    scwAddress: "",
+    chainRpcUrl: "http://localhost:8545",
+    entrypointAddress: entrypointAddress,
+    scwAddress: bobScwAddress,
   });
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/Intermediary.tsx
+++ b/src/Intermediary.tsx
@@ -34,7 +34,7 @@ export const Coordinator: React.FunctionComponent = () => {
     ownerAddress: import.meta.env.VITE_ALICE_ADDRESS,
     intermediaryAddress: myAddress,
     chainRpcUrl: "http://localhost:8545",
-    entrypointAddress: entrypointAddress,
+    entrypointAddress,
     scwAddress: aliceScwAddress,
   });
   const withBob = new IntermediaryClient({
@@ -43,7 +43,7 @@ export const Coordinator: React.FunctionComponent = () => {
     ownerAddress: import.meta.env.VITE_BOB_ADDRESS,
     intermediaryAddress: myAddress,
     chainRpcUrl: "http://localhost:8545",
-    entrypointAddress: entrypointAddress,
+    entrypointAddress,
     scwAddress: bobScwAddress,
   });
 

--- a/src/Wallet.tsx
+++ b/src/Wallet.tsx
@@ -71,6 +71,7 @@ const Wallet: React.FunctionComponent<{ role: Role }> = (props: {
   const [hostNetwork, setHostNetwork] = useState("Scroll");
   const [isModalL1PayOpen, setModalL1PayOpen] = useState<boolean>(false);
   const [userOpHash, setUserOpHash] = useState<string | null>(null);
+  const [payAmount, setPayAmount] = useState<number>(0.5);
   const [errorL1Pay, setErrorL1Pay] = useState<string | null>(null);
 
   const handleL1Pay = async (payee: string, amount: number): Promise<void> => {
@@ -234,7 +235,7 @@ const Wallet: React.FunctionComponent<{ role: Role }> = (props: {
               }}
               errorMessage={errorL1Pay}
               userOpHash={userOpHash}
-              amount={19} // todo: get this dynamically
+              amount={payAmount}
               payee={myPeer}
             />
           </Stack>


### PR DESCRIPTION
Clicking the `L1 Pay` button on the UI now progresses to the `Intermediary.handleUserOp` method but then fails with this error:
```
errors.ts:694 Uncaught (in promise) Error: contract runner does not support sending transactions (operation="sendTransaction", code=UNSUPPORTED_OPERATION, version=6.8.0)
    at makeError (errors.ts:694:21)
    at assert (errors.ts:715:25)
    at send (contract.ts:310:9)
    at Proxy.handleOps (contract.ts:352:22)
    at IntermediaryClient.handleUserOp (IntermediaryClient.ts:182:35)
```

Update: the above error was fixed by attaching `this.signer` to the `StateChannelWallet.entrypointContract` instead of attaching `this.provider`. The reason is that it needs a `signer` in order to send txs (opposed to just invoking read methods)

Latest error: insufficient funds when sending the UserOperation on-chain.
```
Uncaught (in promise) Error: could not coalesce error (error={ "code": -32000, "data": { "message": "sender doesn't have enough funds to send tx. The max upfront cost is: 82743000000000 and the sender's account only has: 0" }, "message": "sender doesn't have enough funds to send tx. The max upfront cost is: 82743000000000 and the sender's account only has: 0" }, payload={ "id": 11, "jsonrpc": "2.0", "method": "eth_sendRawTransaction", "params": [ "..." ] }, code=UNKNOWN_ERROR, version=6.8.0)
```

Update: the above error is resolved after using the latest deployment script that funds accounts and deposits into EntryPoint contract