### PR TITLE
Fix Intermediary Balance 

### DIFF
--- a/clients/StateChannelWallet.ts
+++ b/clients/StateChannelWallet.ts
@@ -257,11 +257,9 @@ export class StateChannelWallet {
     const currentTimestamp: number = Math.floor(Date.now() / 1000); // Unix timestamp in seconds
 
     if (this.myRole() === Participant.Intermediary) {
-      if (this.intermediaryBalance < BigInt(amount)) {
+      if (Number(this.currentState().intermediaryBalance) < BigInt(amount)) {
         throw new Error("Insufficient balance");
       }
-
-      this.intermediaryBalance -= BigInt(amount);
     }
 
     if (
@@ -278,11 +276,16 @@ export class StateChannelWallet {
       timelock: currentTimestamp + HTLC_TIMEOUT * 2, // payment creator always uses TIMEOUT * 2
     };
 
+    const updatedIntermediaryBalance =
+      this.myRole() === Participant.Intermediary
+        ? Number(this.currentState().intermediaryBalance) - amount
+        : this.currentState().intermediaryBalance;
+
     const updated: StateStruct = {
       owner: this.ownerAddress,
       intermediary: this.intermediaryAddress,
       turnNum: Number(this.currentState().turnNum) + 1,
-      intermediaryBalance: this.intermediaryBalance,
+      intermediaryBalance: updatedIntermediaryBalance,
       htlcs: [...this.currentState().htlcs, htlc],
     };
 

--- a/clients/StateChannelWallet.ts
+++ b/clients/StateChannelWallet.ts
@@ -168,18 +168,15 @@ export class StateChannelWallet {
   /**
    * getBalance checks the blockchain for the current balance of the wallet.
    */
-  async getBalance(): Promise<number> {
-    // TODO: Casting a bigint to a number is dangerous
-    return Number(
-      await this.chainProvider.getBalance(this.scBridgeWalletAddress),
-    );
+  async getBalance(): Promise<bigint> {
+    return await this.chainProvider.getBalance(this.scBridgeWalletAddress);
   }
 
-  get intermediaryBalance(): number {
-    return Number(this.currentState().intermediaryBalance);
+  get intermediaryBalance(): bigint {
+    return BigInt(this.currentState().intermediaryBalance);
   }
 
-  async getOwnerBalance(): Promise<number> {
+  async getOwnerBalance(): Promise<bigint> {
     const walletBalance = await this.getBalance();
     return walletBalance - this.intermediaryBalance;
   }
@@ -311,7 +308,7 @@ export class StateChannelWallet {
     // the HTLC is for the intermediary, then the update must be recorded.
     let newintermediaryBalance = this.intermediaryBalance;
     if (unlockTarget.to === Participant.Intermediary) {
-      newintermediaryBalance += Number(BigInt(unlockTarget.amount));
+      newintermediaryBalance += BigInt(unlockTarget.amount);
     }
 
     const updated: StateStruct = {

--- a/clients/StateChannelWallet.ts
+++ b/clients/StateChannelWallet.ts
@@ -182,7 +182,7 @@ export class StateChannelWallet {
   }
 
   async getIntermediaryBalance(): Promise<number> {
-    return Number(this.intermediaryBalance);
+    return Number(this.currentState().intermediaryBalance);
   }
 
   async getOwnerBalance(): Promise<number> {

--- a/src/Intermediary.tsx
+++ b/src/Intermediary.tsx
@@ -116,14 +116,7 @@ export const Intermediary: React.FunctionComponent<{
         .catch((e) => {
           console.error(e);
         });
-      props.client
-        .getIntermediaryBalance()
-        .then((b) => {
-          setIntermediaryBalance(b);
-        })
-        .catch((e) => {
-          console.error(e);
-        });
+      setIntermediaryBalance(props.client.intermediaryBalance);
     }, UI_UPDATE_PERIOD);
     return () => {
       clearInterval(interval);

--- a/src/Intermediary.tsx
+++ b/src/Intermediary.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import {
   IntermediaryClient,
   IntermediaryCoordinator,
@@ -14,8 +14,8 @@ import {
   Typography,
 } from "@mui/material";
 import { blo } from "blo";
-import { UI_UPDATE_PERIOD } from "./constants";
 import { formatEther } from "ethers";
+import { useBalances } from "./useBalances";
 
 export const Coordinator: React.FunctionComponent = () => {
   // @ts-expect-error
@@ -103,26 +103,7 @@ export const Coordinator: React.FunctionComponent = () => {
 export const Intermediary: React.FunctionComponent<{
   client: IntermediaryClient;
 }> = (props: { client: IntermediaryClient }) => {
-  const [ownerBalance, setOwnerBalance] = useState(0);
-  const [intermediaryBalance, setIntermediaryBalance] = useState(0);
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      props.client
-        .getOwnerBalance()
-        .then((b) => {
-          setOwnerBalance(Number(b));
-        })
-        .catch((e) => {
-          console.error(e);
-        });
-      setIntermediaryBalance(Number(props.client.intermediaryBalance));
-    }, UI_UPDATE_PERIOD);
-    return () => {
-      clearInterval(interval);
-    };
-  }, []);
-
+  const [ownerBalance, intermediaryBalance] = useBalances(props.client);
   return (
     <>
       <Stack

--- a/src/Intermediary.tsx
+++ b/src/Intermediary.tsx
@@ -111,7 +111,7 @@ export const Intermediary: React.FunctionComponent<{
       props.client
         .getOwnerBalance()
         .then((b) => {
-          setOwnerBalance(b);
+          setOwnerBalance(Number(b));
         })
         .catch((e) => {
           console.error(e);

--- a/src/Intermediary.tsx
+++ b/src/Intermediary.tsx
@@ -116,7 +116,7 @@ export const Intermediary: React.FunctionComponent<{
         .catch((e) => {
           console.error(e);
         });
-      setIntermediaryBalance(props.client.intermediaryBalance);
+      setIntermediaryBalance(Number(props.client.intermediaryBalance));
     }, UI_UPDATE_PERIOD);
     return () => {
       clearInterval(interval);

--- a/src/Wallet.tsx
+++ b/src/Wallet.tsx
@@ -28,6 +28,7 @@ import { AddressIcon, AddressIconSmall } from "./AddressIcon";
 import { blo } from "blo";
 import { UI_UPDATE_PERIOD } from "./constants";
 import { formatEther } from "ethers";
+import { useBalances } from "./useBalances";
 
 let myAddress: string = "placholder";
 let mySigningKey: string;
@@ -72,8 +73,7 @@ const Wallet: React.FunctionComponent<{ role: Role }> = (props: {
     // @ts-expect-error
     import.meta.env.VITE_IRENE_ADDRESS,
   );
-  const [intermediaryBalance, setIntermediaryBalance] = useState(0);
-  const [ownerBalance, setOwnerBalance] = useState(0);
+
   const [recipient, setRecipient] = useState(myPeer);
   const [hostNetwork, setHostNetwork] = useState("Scroll");
   const [isModalL1PayOpen, setModalL1PayOpen] = useState<boolean>(false);
@@ -105,22 +105,7 @@ const Wallet: React.FunctionComponent<{ role: Role }> = (props: {
     }),
   );
 
-  useEffect(() => {
-    const interval = setInterval(() => {
-      wallet
-        .getOwnerBalance()
-        .then((b) => {
-          setOwnerBalance(Number(b));
-        })
-        .catch((e) => {
-          console.error(e);
-        });
-      setIntermediaryBalance(Number(wallet.intermediaryBalance));
-    }, UI_UPDATE_PERIOD);
-    return () => {
-      clearInterval(interval);
-    };
-  }, []);
+  const [ownerBalance, intermediaryBalance] = useBalances(wallet);
 
   const prefersDarkMode = useMediaQuery("(prefers-color-scheme: dark)");
   const theme = React.useMemo(

--- a/src/Wallet.tsx
+++ b/src/Wallet.tsx
@@ -115,7 +115,7 @@ const Wallet: React.FunctionComponent<{ role: Role }> = (props: {
         .catch((e) => {
           console.error(e);
         });
-      setIntermediaryBalance(wallet.intermediaryBalance);
+      setIntermediaryBalance(Number(wallet.intermediaryBalance));
     }, UI_UPDATE_PERIOD);
     return () => {
       clearInterval(interval);

--- a/src/Wallet.tsx
+++ b/src/Wallet.tsx
@@ -115,14 +115,7 @@ const Wallet: React.FunctionComponent<{ role: Role }> = (props: {
         .catch((e) => {
           console.error(e);
         });
-      wallet
-        .getIntermediaryBalance()
-        .then((b) => {
-          setIntermediaryBalance(b);
-        })
-        .catch((e) => {
-          console.error(e);
-        });
+      setIntermediaryBalance(wallet.intermediaryBalance);
     }, UI_UPDATE_PERIOD);
     return () => {
       clearInterval(interval);

--- a/src/Wallet.tsx
+++ b/src/Wallet.tsx
@@ -110,7 +110,7 @@ const Wallet: React.FunctionComponent<{ role: Role }> = (props: {
       wallet
         .getOwnerBalance()
         .then((b) => {
-          setOwnerBalance(b);
+          setOwnerBalance(Number(b));
         })
         .catch((e) => {
           console.error(e);

--- a/src/useBalances.tsx
+++ b/src/useBalances.tsx
@@ -1,0 +1,26 @@
+import { useState, useEffect } from "react";
+import { type StateChannelWallet } from "../clients/StateChannelWallet";
+import { UI_UPDATE_PERIOD } from "./constants";
+
+export function useBalances(client: StateChannelWallet): [number, number] {
+  const [ownerBalance, setOwnerBalance] = useState(0);
+  const [intermediaryBalance, setIntermediaryBalance] = useState(0);
+  useEffect(() => {
+    const interval = setInterval(() => {
+      client
+        .getOwnerBalance()
+        .then((b) => {
+          setOwnerBalance(Number(b));
+        })
+        .catch((e) => {
+          console.error(e);
+        });
+      setIntermediaryBalance(Number(client.intermediaryBalance));
+    }, UI_UPDATE_PERIOD);
+    return () => {
+      clearInterval(interval);
+    };
+  }, []);
+
+  return [ownerBalance, intermediaryBalance];
+}


### PR DESCRIPTION
I cherry-picked some work from #111 for this. 

* removes the `intermediaryBalance` protected member of the `StateChannelWallet` class.
* replaces with a getter which computes the balance from the latest state. This is the off chain source of truth about the intermediary balance
* removes code trying to read intermediary balance from the chain
* removes any bigint => Number casts from the clients. This happens in the UI now, but that can be fixed easily later on. 
* DRYs out the UI quite a bit by introducing a `useBalances` hook