### PR TITLE
Add Eject modal to UI

### DIFF
--- a/src/Wallet.tsx
+++ b/src/Wallet.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from "react";
 import BoltIcon from "@mui/icons-material/Bolt";
 import AccessTimeIcon from "@mui/icons-material/AccessTime";
+import EjectIcon from "@mui/icons-material/Eject";
 import logo from "./assets/logo.png";
 import "./Wallet.css";
 import {
@@ -28,6 +29,7 @@ import { AddressIcon, AddressIconSmall } from "./AddressIcon";
 import { blo } from "blo";
 import { formatEther } from "ethers";
 import { useBalances } from "./useBalances";
+import EjectModal from "./modals/Eject";
 
 let myAddress: string = "placholder";
 let mySigningKey: string;
@@ -76,6 +78,7 @@ const Wallet: React.FunctionComponent<{ role: Role }> = (props: {
   const [recipient, setRecipient] = useState(myPeer);
   const [hostNetwork, setHostNetwork] = useState("Scroll");
   const [isModalL1PayOpen, setModalL1PayOpen] = useState<boolean>(false);
+  const [isModalEjectOpen, setModalEjectOpen] = useState<boolean>(false);
   const [userOpHash, setUserOpHash] = useState<string | null>(null);
   const [payAmount, setPayAmount] = useState<string>("0.05");
   const [errorL1Pay, setErrorL1Pay] = useState<string | null>(null);
@@ -266,7 +269,22 @@ const Wallet: React.FunctionComponent<{ role: Role }> = (props: {
                 sx={{ width: 24, height: 24 }}
               />
             </Tooltip>
-            <Button>Eject</Button>
+            <ButtonGroup variant="outlined" aria-label="outlined button group">
+              <Button
+                size="medium"
+                onClick={() => {
+                  setModalEjectOpen(true);
+                }}
+              >
+                <EjectIcon style={{ marginRight: "5px" }} /> Eject
+              </Button>
+            </ButtonGroup>
+            <EjectModal
+              isOpen={isModalEjectOpen}
+              onClose={() => {
+                setModalEjectOpen(false);
+              }}
+            />
           </Stack>
         </Stack>
       </Card>

--- a/src/modals/Eject.tsx
+++ b/src/modals/Eject.tsx
@@ -35,15 +35,9 @@ const EjectModal: React.FC<EjectProps> = ({ isOpen, onClose }) => {
           <br></br>
           <Typography variant="body1">
             If implemented, this would initiate a challenge where the
-          </Typography>
-          <Typography variant="body1">
-            SCBridge-Wallet owner sends its latest known state on-chain
-          </Typography>
-          <Typography variant="body1">
-            and the Intermediary has a timeout period where they can{" "}
-          </Typography>
-          <Typography variant="body1">
-            respond with their latest state if it has a higher turn number.
+            SCBridge-Wallet owner sends its latest known state on-chain and the
+            Intermediary has a timeout period where they can respond with their
+            latest state if it has a higher turn number.
           </Typography>
         </Box>
       </DialogContent>

--- a/src/modals/Eject.tsx
+++ b/src/modals/Eject.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import WarningAmberIcon from "@mui/icons-material/WarningAmber";
+import {
+  Box,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Typography,
+} from "@mui/material";
+
+interface EjectProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const EjectModal: React.FC<EjectProps> = ({ isOpen, onClose }) => {
+  return (
+    <Dialog
+      open={isOpen}
+      onClose={onClose}
+      aria-labelledby="alert-dialog-title"
+      aria-describedby="alert-dialog-description"
+    >
+      <DialogTitle id="alert-dialog-title">
+        <WarningAmberIcon
+          style={{ marginRight: "10px", verticalAlign: "middle" }}
+        />
+        Eject Intermediary
+      </DialogTitle>
+      <DialogContent>
+        <Box>
+          <Typography variant="h6" color="error">
+            Eject feature is not fully implemented
+          </Typography>
+          <br></br>
+          <Typography variant="body1">
+            If implemented, this would initiate a challenge where the
+          </Typography>
+          <Typography variant="body1">
+            SCBridge-Wallet owner sends its latest known state on-chain
+          </Typography>
+          <Typography variant="body1">
+            and the Intermediary has a timeout period where they can{" "}
+          </Typography>
+          <Typography variant="body1">
+            respond with their latest state if it has a higher turn number.
+          </Typography>
+        </Box>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default EjectModal;


### PR DESCRIPTION
Quick and easy way to show we've thought about the necessity of the `Eject` feature, but have not fully implemented it. This is what shows up after clicking the `EJECT` button (no calls to the backend):

<img width="450" alt="image" src="https://github.com/statechannels/SCBridge-Wallet/assets/35908605/c07aab19-a4ce-4cfd-8e16-be36c37caf7f">
