### PR TITLE
refactor `SCBridgeWallet.validateUserOp`

### DIFF
--- a/contracts/SCBridgeWallet.sol
+++ b/contracts/SCBridgeWallet.sol
@@ -197,7 +197,7 @@ contract SCBridgeWallet is IAccount {
       return validateUserOpCHALLENGE_RAISED(userOp, userOpHash);
     }
 
-    // or is open, in which case we need to appy extra conditions:
+    // or is open, in which case we need to apply extra conditions:
     return validateUserOpOPEN(userOp, userOpHash);
   }
 

--- a/test/SCBridgeWallet.test.ts
+++ b/test/SCBridgeWallet.test.ts
@@ -276,7 +276,7 @@ describe("SCBridgeWallet", function () {
         .staticCall(userOp, hash, 0);
       expect(result).to.equal(0);
     });
-    it("only allows specific functions to be called when signed by one actor", async function () {
+    it("allows specific functions to be called when signed by one actor", async function () {
       const { nitroSCW, owner } = await deploySCBridgeWallet();
       const n = await ethers.provider.getNetwork();
 


### PR DESCRIPTION
This only tries to extract a `intermediarySig` if it is required, meaning that a single 65 byte signature will still work if only a single signature is required.

Closes #109 , but not by using 130 byte signatures everywhere. 