### PR TITLE
Add polygon zkevm deploy script

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -21,6 +21,11 @@ const config: HardhatUserConfig = {
       accounts:
         process.env.DEPLOY_KEY !== undefined ? [process.env.DEPLOY_KEY] : [],
     },
+    polygonzkevm: {
+      url: "https://rpc.public.zkevm-test.net",
+      accounts:
+        process.env.DEPLOY_KEY !== undefined ? [process.env.DEPLOY_KEY] : [],
+    },
     // Used for testing
     hardhat: {
       chainId:

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "chain:b": "IS_DESTINATION=true yarn hardhat node --port 8546",
     "deploy:b": "npx hardhat run --network b scripts/deploy.ts",
     "deploy-and-start": "yarn deploy:a && yarn deploy:b && yarn start",
-    "deploy:scroll": "npx hardhat run --network scroll scripts/deploy.ts"
+    "deploy:scroll": "npx hardhat run --network scroll scripts/deploy.ts",
+    "deploy:poly": "npx hardhat run --network polygonzkevm scripts/deploy.ts"
   },
   "packageManager": "yarn@1.22.19",
   "devDependencies": {

--- a/src/chains.ts
+++ b/src/chains.ts
@@ -30,6 +30,14 @@ export type ChainID = bigint;
 
 export const chains: ChainData[] = [
   {
+    name: "Polygon zkEVM Testnet",
+    symbol: "polyETH",
+    url: "https://rpc.public.zkevm-test.net",
+    chainID: 1442n,
+    exchangeRate: 1,
+    explorer: "",
+  },
+  {
     url: "http://localhost:8545",
     chainID: 31337n,
     name: "hardhat 1",


### PR DESCRIPTION
Adds a yarn command to deploy to polygon zkevm.

Currently blocked on running it by lack of funds, since the faucet only hands out `0.02 eth` and we fund accounts with `0.01` eth.