### PR TITLE
Add a simple topup script

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "deploy:b": "npx hardhat run --network b scripts/deploy.ts",
     "deploy-and-start": "yarn deploy:a && yarn deploy:b && yarn start",
     "deploy:scroll": "npx hardhat run --network scroll scripts/deploy.ts",
-    "deploy:poly": "npx hardhat run --network polygonzkevm scripts/deploy.ts"
+    "deploy:poly": "npx hardhat run --network polygonzkevm scripts/deploy.ts",
+    "topup:scroll": "npx hardhat run --network scroll scripts/topup.ts",
+    "topup:poly": "npx hardhat run --network polygonzkevm scripts/topup.ts"
   },
   "packageManager": "yarn@1.22.19",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "deploy:scroll": "npx hardhat run --network scroll scripts/deploy.ts",
     "deploy:poly": "npx hardhat run --network polygonzkevm scripts/deploy.ts",
     "topup:scroll": "npx hardhat run --network scroll scripts/topup.ts",
-    "topup:poly": "npx hardhat run --network polygonzkevm scripts/topup.ts"
+    "topup:poly": "npx hardhat run --network polygonzkevm scripts/topup.ts",
+    "topup:all": "yarn topup:scroll && yarn topup:poly"
   },
   "packageManager": "yarn@1.22.19",
   "devDependencies": {

--- a/scripts/topup.ts
+++ b/scripts/topup.ts
@@ -1,0 +1,52 @@
+import { ethers } from "hardhat";
+import dotenv from "dotenv";
+
+import { type HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+
+async function main(): Promise<void> {
+  dotenv.config();
+  const aliceSCWAddress = process.env.VITE_ALICE_SCW_ADDRESS ?? "";
+  const bobSCWAddress = process.env.VITE_BOB_SCW_ADDRESS ?? "";
+
+  const ireneAddress = process.env.VITE_IRENE_ADDRESS ?? "";
+
+  const fundingTarget = BigInt(process.env.VITE_SCW_DEPOSIT ?? "");
+  const hardhatFundedAccount = (await ethers.getSigners())[0];
+  await fundTo(
+    [aliceSCWAddress, bobSCWAddress, ireneAddress],
+    fundingTarget,
+    hardhatFundedAccount,
+  );
+}
+
+async function fundTo(
+  addresses: string[],
+  amount: bigint,
+  fundedAccount: HardhatEthersSigner,
+): Promise<void> {
+  for (const address of addresses) {
+    const balance = await ethers.provider.getBalance(address);
+    if (balance >= amount) {
+      console.log(
+        `Skipping funding ${address} it already has ${ethers.formatEther(
+          amount,
+        )} ETH`,
+      );
+      continue;
+    }
+
+    const amountToFund = amount - balance;
+    console.log(
+      `Funding ${address} with ${ethers.formatEther(
+        amountToFund,
+      )} ETH to reach ${ethers.formatEther(amount)} ETH`,
+    );
+    await (
+      await fundedAccount.sendTransaction({
+        to: address,
+        value: amountToFund,
+      })
+    ).wait();
+  }
+}
+void main();

--- a/scripts/topup.ts
+++ b/scripts/topup.ts
@@ -10,11 +10,11 @@ async function main(): Promise<void> {
 
   const ireneAddress = process.env.VITE_IRENE_ADDRESS ?? "";
 
-  const fundingTarget = BigInt(process.env.VITE_SCW_DEPOSIT ?? "");
+  const fundingAmount = BigInt(process.env.VITE_SCW_DEPOSIT ?? "");
   const hardhatFundedAccount = (await ethers.getSigners())[0];
   await fundTo(
     [aliceSCWAddress, bobSCWAddress, ireneAddress],
-    fundingTarget,
+    fundingAmount,
     hardhatFundedAccount,
   );
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,6 @@
     "hardhat.config.ts",
     "tsconfig.json",
     "vite.config.ts",
-    "scripts/deploy.ts"
+    "scripts"
   ]
 }


### PR DESCRIPTION
Based on #166 

Adds a simple script that funds Alice, Bob and Irene back to the "starting balance". This should let us easily reset the SCW wallet balances, so we can easily do multiple takes of the video.

It can be run by running ` DEPLOY_KEY=SECRET_KEY_FROM_SLACK yarn topup:all`