### PR TITLE
More deploy targets

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -26,6 +26,21 @@ const config: HardhatUserConfig = {
       accounts:
         process.env.DEPLOY_KEY !== undefined ? [process.env.DEPLOY_KEY] : [],
     },
+    goerli: {
+      url: "https://goerli.blockpi.network/v1/rpc/public",
+      accounts:
+        process.env.DEPLOY_KEY !== undefined ? [process.env.DEPLOY_KEY] : [],
+    },
+    sepolia: {
+      url: "https://eth-sepolia.public.blastapi.io",
+      accounts:
+        process.env.DEPLOY_KEY !== undefined ? [process.env.DEPLOY_KEY] : [],
+    },
+    mantle: {
+      url: "https://rpc.testnet.mantle.xyz",
+      accounts:
+        process.env.DEPLOY_KEY !== undefined ? [process.env.DEPLOY_KEY] : [],
+    },
     // Used for testing
     hardhat: {
       chainId:

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -10,7 +10,9 @@ const deployFunc = async function (): Promise<void> {
     hardhatFundedAccount.address,
   );
   console.log(
-    `Deployer (${hardhatFundedAccount.address}) starting balance ${startingBalance}`,
+    `Deployer (${
+      hardhatFundedAccount.address
+    }) starting balance ${ethers.formatEther(startingBalance)} ETH`,
   );
   console.log("Starting deployment...");
 

--- a/src/chains.ts
+++ b/src/chains.ts
@@ -2,7 +2,10 @@ export type ChainName =
   | "Hardhat A"
   | "Hardhat B"
   | "Polygon zkEVM Testnet"
-  | "scroll";
+  | "scroll"
+  | "goerli"
+  | "sepolia"
+  | "mantle";
 
 export interface ChainData {
   /**
@@ -66,5 +69,29 @@ export const chains: ChainData[] = [
     symbol: "ETH",
     explorer: "https://sepolia.scrollscan.com/address/",
     exchangeRate: 1,
+  },
+  {
+    chainID: 5n,
+    symbol: "ETH",
+    name: "goerli",
+    explorer: "https://goerli.etherscan.io",
+    exchangeRate: 1,
+    url: "https://goerli.blockpi.network/v1/rpc/public",
+  },
+  {
+    chainID: 11155111n,
+    symbol: "ETH",
+    name: "sepolia",
+    explorer: "https://sepolia.etherscan.io",
+    exchangeRate: 1,
+    url: "https://eth-sepolia.public.blastapi.io",
+  },
+  {
+    chainID: 5001n,
+    symbol: "MNT",
+    name: "mantle",
+    explorer: "https://explorer.testnet.mantle.xyz",
+    exchangeRate: 1,
+    url: "https://rpc.testnet.mantle.xyz",
   },
 ];


### PR DESCRIPTION
This just adds the hardhat config for the additional chains I've deployed contracts to (or I'm about to deploy to). I've also updated `chain.ts` to include the chains.

See[ this doc](https://www.notion.so/statechannels/Deployments-9687f10a5f5d456f8984941a8d64154f) for the addresses.

